### PR TITLE
Create using-tailscale-on-windows-to-network-more-easily-with-wsl2-an…

### DIFF
--- a/using-tailscale-on-windows-to-network-more-easily-with-wsl2-and-visual-studio-code.md
+++ b/using-tailscale-on-windows-to-network-more-easily-with-wsl2-and-visual-studio-code.md
@@ -1,0 +1,9 @@
+Hello, Scott. I found an mistake in the blog post about Tailscale and VSCode. You had wrote:
+
+> Glenn then installs the VS Code Remote Development pack and connects using Remote via SSH to my Tailscale IP. Here you can see VS Code from Glenn's machine **is actually installing the VS Code Server and remote developers**, and Glenn and code with VS Code architecturally split in half with the client on his Windows machine and the server on my WSL2 instance. 
+
+But on the screenshot we can't see it. Instead, we are seeing .NET packages and simplest VSCode (not VSC in the web).
+
+![](https://hanselmanblogcontent.azureedge.net/Windows-Live-Writer/Using-Tailscale-to-communicate-with_EC92/image_thumb_4.png)
+
+Overall, the sentence above seems some strange.


### PR DESCRIPTION
…d-visual-studio-code.md

Hello, Scott. I found an mistake in the blog post [about Tailscale and VSCode](https://www.hanselman.com/blog/using-tailscale-on-windows-to-network-more-easily-with-wsl2-and-visual-studio-code). You had wrote:

> Glenn then installs the VS Code Remote Development pack and connects using Remote via SSH to my Tailscale IP. Here you can see VS Code from Glenn's machine **is actually installing the VS Code Server and remote developers**, and Glenn and code with VS Code architecturally split in half with the client on his Windows machine and the server on my WSL2 instance. 

But on the screenshot we can't see it. Instead, we are seeing .NET packages and simplest VSCode (not VSC in the web).

![](https://hanselmanblogcontent.azureedge.net/Windows-Live-Writer/Using-Tailscale-to-communicate-with_EC92/image_thumb_4.png)

Overall, the sentence seems some strange.